### PR TITLE
Jpb/config for multiple experiments

### DIFF
--- a/config/evaluate.yaml
+++ b/config/evaluate.yaml
@@ -3,7 +3,7 @@ enhanced_dir: ${..paths.enhanced_dir}
 
 results_file: ${..paths.results_file}
 
-segment_dir: ${..paths.scratch}/segments/{device}
+segment_dir: ${..paths.segment_dir}
 
 csv_dir: ${..paths.echi}/metadata/ref/dev # Path to the CSV files for evaluation
 ref_segment_dir: ${..paths.ref_segment_dir} # Path to the reference segment directory

--- a/config/paths.yaml
+++ b/config/paths.yaml
@@ -19,6 +19,7 @@ signal_dir: ${paths.echi}/{device}/{dataset}
 echi_signal: ${paths.signal_dir}/{session}.{device}.wav
 ref_signal_dir: ${paths.echi}/ref/{dataset}
 ref_signal_file: ${paths.ref_signal_dir}/${paths.signal_id}.wav
+
 # chime9_echi metadata layout
 sessions_file: ${paths.echi}/metadata/sessions.${..shared.dataset}.csv
 segment_info_dir: ${paths.echi}/metadata/ref/{dataset}
@@ -27,7 +28,10 @@ segment_info_file: ${paths.segment_info_dir}/${paths.signal_id}.csv
 # Path to the reference segment directory
 ref_segment_dir: ${paths.scratch}/ref_segments/{dataset}/{device}
 
-enhanced_signal: ${paths.enhanced_dir}/${paths.signal_id}.wav
+# Directories and paths where outputs are produced
+segment_dir: ${..paths.scratch}/${..shared.exp}/segments/{device}
+results_file: ${..paths.scratch}/${..shared.exp}/results/results.${..shared.dataset}.{device}.json
+report_file: ${..paths.scratch}/${..shared.exp}/reports/report.${..shared.dataset}.{device}.{session}.{pid}.json
 
-results_file: ${..paths.scratch}/results/results.${..shared.dataset}.{device}.json
-report_file: ${..paths.scratch}/reports/report.${..shared.dataset}.{device}.{session}.{pid}.json
+# Names for the enhanced signals
+enhanced_signal: ${paths.enhanced_dir}/${paths.signal_id}.wav

--- a/config/shared.yaml
+++ b/config/shared.yaml
@@ -3,3 +3,5 @@
 devices: [ha, aria] # Devices to process
 dataset: dev # Dataset to use for processing
 sample_rate: 16000 # Reference sample rate.
+
+exp: exp # Experiment name - change this to create a new experiment


### PR DESCRIPTION
Allowing easy configuration for multiple experiments.

A variable 'exp' has been introduced in the config to define a top-level directory name for the segments,
results and reports, etc from each run.