### PR TITLE
Remove failed segments before reporting

### DIFF
--- a/config/metrics_test.yaml
+++ b/config/metrics_test.yaml
@@ -1,2 +1,18 @@
-# Minimal configuration for testing purposes
+# GPU-free configuration for testing purposes
+
+# signal related metrics
+# -- sir: signal to interference ratio
+# -- sar: signal to artifact ratio
+# -- sdr: signal to distortion ratio
+# -- ci-sdr: scale-invariant signal to distortion ratio
+# -- si-snri: scale-invariant signal to noise ratio improvement
+- name: pysepm
 - name: signal_metric
+
+# pesq related metrics
+- name: pesq
+
+# stoi related metrics
+# -- stoi: short-time objective intelligibility
+- name: stoi
+


### PR DESCRIPTION
Reporting failing when encountering bad segments.

A very small number of segments fail when running Versa -- leading to empty entries. These unexpected fails
were causing the summary reports to bug out.  There is now a results cleaning step that filters out the bad
scores and shows a warning to list the segments in question.
