### PR TITLE
Squashed excessive logging into debug, and now skips when csv files a…

### DIFF
--- a/src/signal_tools.py
+++ b/src/signal_tools.py
@@ -135,20 +135,25 @@ def segment_all_signals(
             dataset=dataset, device=device, segment_type="individual"
         )
 
-        logging.info(f"Segmenting {device}, {pid} reference signals into {output_dir}")
+        logging.debug(f"Segmenting {device}, {pid} reference signals into {output_dir}")
         wav_file = signal_template.format(
             dataset=dataset, session=session, device=device, pid=pid
         )
         csv_file = segment_info_file.format(
             dataset=dataset, session=session, device=device, pid=pid
         )
+
+        if not Path(csv_file).exists():
+            logging.warning(f"WARNING: csv file not found at {csv_file}")
+            continue
+
         segment_signal(wav_file, csv_file, output_dir)
 
         # Segment the summed reference signal using this PIDs segment info
         output_dir = output_dir_template.format(
             dataset=dataset, device=device, segment_type="summed"
         )
-        logging.info(f"Segmenting {device}, {pid} reference signals into {output_dir}")
+        logging.debug(f"Segmenting {device}, {pid} reference signals into {output_dir}")
 
         pids = [p for s, d, p in session_tuples if s == session and d == device]
         wav_files = [


### PR DESCRIPTION
…ren't found.

There was a logging line twice for each session/device/pid in segment_all_signals, with tqdm also enabled. Dropped logging.info calls to logging.debug calls.

Also added a catch for if a csv file can't be found; this is expected for some sessions, e.g. when the aria isn't present but wasn't handled.